### PR TITLE
모든 Region-InstanceType-AvailabilityZone 쌍의 개수 모니터링 기능 추가

### DIFF
--- a/data-collection/ec2/monitoring.py
+++ b/data-collection/ec2/monitoring.py
@@ -11,9 +11,14 @@ def post_message(url, data):
     return urllib.request.urlopen(req, data)
 
 if __name__ == "__main__":
+    region_cnt = pickle.load(open("/home/ec2-user/WorkloadCreator/base.pickle", "rb"))
+    azs = 0
+    for instance, query in region_cnt.items():
+        for ra in query:
+            azs += ra[1]
     workload_result = pickle.load(open("/home/ec2-user/SpotInfo/pkls/bin_packed_workload.pickle", "rb"))
     url = "https://hooks.slack.com/services/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"
-    message = f"Spot Placement Score Monitoring - the number of necessary accounts to fetch all scores {len(workload_result)}"
+    message = f"<Spot Placement Score Monitoring>\n - the number of necessary accounts to fetch all scores : {len(workload_result)}\n - the number of all Region-InstanceType-AvailabilityZone : {azs}"
     data = generate_curl_message(message)
     response = post_message(url, data)
     print(response.status)


### PR DESCRIPTION
필요 계정의 수만 모니터링한다면, 그 변화가 세세히 눈에 들어오지 않아 기능이 제대로 동작하고 있는 것인지 알기 어려움.
때문에, 기능이 제대로 동작중인지를 확인하기 위해 빠르게 변화하는 Region-InstanceType-AvailabilityZone 쌍의 개수를 모니터링하는 기능을 추가함.