### PR TITLE
binpacking시 발생하는 데이터 유실 가능성 제거

### DIFF
--- a/data-collection/ec2/binpacking.py
+++ b/data-collection/ec2/binpacking.py
@@ -63,7 +63,6 @@ def CBC(query, capacity):
     return to_return
 
 if __name__ == "__main__":
-    
     collect_num_az()
 
     region_cnt = pickle.load(open('/home/ec2-user/WorkloadCreator/base.pickle', 'rb'))
@@ -89,6 +88,10 @@ if __name__ == "__main__":
             if len(f_query) == 50:
                 workload_result.append(f_query)
                 f_query = []
+
+    if len(f_query) != 0:
+        workload_result.append(f_query)
+        f_query = []
 
     end_time = time.time()
     


### PR DESCRIPTION
binpacking시 50개 단위로 workload를 각 credentials에 할당하는 과정에서,
마지막 workload를 리스트에 append 했을 때, append된 workload의 개수가 50개 미만이라면 해당 list는 credential에 할당되지 않은 상태로 프로그램이 종료되어왔습니다.

해당 오류를 수정하였습니다.

<img width="486" alt="스크린샷 2022-07-18 오전 9 58 16" src="https://user-images.githubusercontent.com/66048830/179432602-6716a83c-9c3c-4c7a-847d-486aa8d7103f.png">
<img width="486" alt="스크린샷 2022-07-18 오전 9 57 58" src="https://user-images.githubusercontent.com/66048830/179432609-661ec846-bf92-4b21-8a9e-576171f57014.png">
보시는 바와 같이 같은 region-instancetype-az 개수를 가지고 있지만, 사용하는 credentials의 개수는 1개 더 많음을 확인할 수 있습니다.