### PR TITLE
remove timestamp column in collect process

### DIFF
--- a/collection/aws/ec2_collector/load_spot_placement_score.py
+++ b/collection/aws/ec2_collector/load_spot_placement_score.py
@@ -35,12 +35,10 @@ def get_sps():
     sps_dict = {'InstanceType' : [],
                 'Region' : [],
                 'AvailabilityZoneId': [],
-                'SPS' : [],
-                'TimeStamp' : []}
+                'SPS' : []}
 
     for sps in sps_list:
         for info in sps[3]:
-            sps_dict['TimeStamp'].append(now_time)
             sps_dict['InstanceType'].append(sps[1])
             sps_dict['Region'].append(info['Region'])
             sps_dict['AvailabilityZoneId'].append(info['AvailabilityZoneId'])

--- a/collection/aws/ec2_collector/load_spotinfo.py
+++ b/collection/aws/ec2_collector/load_spotinfo.py
@@ -29,12 +29,10 @@ def get_spotinfo():
                      'Memory GiB' : [],
                      'Savings' : [],
                      'IF' : [],
-                     'SpotPrice' : [],
-                     'TimeStamp' : []}
+                     'SpotPrice' : []}
     
     # remove column name from data using indexing
     for spotinfo in spotinfo_list[2:-1]:
-        spotinfo_dict['TimeStamp'].append(now_time)
         spotinfo_dict['Region'].append(spotinfo[0])
         spotinfo_dict['InstanceType'].append(spotinfo[1])
         spotinfo_dict['vCPU'].append(spotinfo[2])


### PR DESCRIPTION
timestamp는 join 완료 이후 일괄적으로 적용하도록 코드를 작성하였기 때문에,
spotinfo와 sps의 collect 과정에서 timestamp를 기록하지 않도록 수정하였습니다.