### PR TITLE
함수에 인자로 넘겨주는 값의 자료형 지정 에러 해결

### DIFF
--- a/collection/aws/ec2_collector/load_metadata.py
+++ b/collection/aws/ec2_collector/load_metadata.py
@@ -4,7 +4,7 @@ from collections import Counter
 
 
 # get all available regions
-def get_regions(session: Session, region='us-east-1') -> list:
+def get_regions(session: boto3.session.Session, region='us-east-1') -> list:
     client = session.client('ec2', region_name=region)
     describe_args = {
         'AllRegions': False
@@ -13,7 +13,7 @@ def get_regions(session: Session, region='us-east-1') -> list:
 
 
 # get instance-az information by region
-def get_region_instances(session: Session, region: str):
+def get_region_instances(session: boto3.session.Session, region: str):
     client = session.client('ec2', region_name=region)
     describe_args = {
         'LocationType': 'availability-zone',


### PR DESCRIPTION
load_metadata.py의 Session을, boto3.session.Session으로 수정