### PR TITLE
modify way to make dataframe of sku

### DIFF
--- a/collection/gcp/collector/gcp_load_sku.py
+++ b/collection/gcp/collector/gcp_load_sku.py
@@ -1,9 +1,9 @@
 from google.cloud import billing_v1
 from google.protobuf.json_format import MessageToDict
-import proto.marshal.collections.repeated as pr
 import pandas as pd
 from datetime import datetime
 import pickle
+import os
 
 
 def get_service_list():
@@ -174,5 +174,9 @@ if __name__ == '__main__':
     df_sku['timestamp'] = date_time
 
     # save as pickle
-    with open('C:/Users/wynter/Desktop/DDPS/gcp_price_data/gcp_price.pkl', 'wb') as f:
+    save_path = '../../../../gcp_price_data'
+    if os.path.isdir(save_path) == False:
+        os.mkdir(save_path)
+
+    with open(save_path + '/gcp_price.pkl', 'wb') as f:
         pickle.dump(df_sku, f)


### PR DESCRIPTION
### [GCP] sku dataframe 구조 변경
**1. 기존 dataframe의 'pricing_info' 컬럼 내부에 있는 필드들을 분할**

![image](https://user-images.githubusercontent.com/72314987/181195838-dade492f-26c1-4cc3-ad29-cfe4ac868ede.png)

기존 dataframe의 pricing_info 컬럼에 존재하던 데이터는 API의 PricingInfo 객체입니다.
앞서 조사한바로 쿼리 요청 시 time range를 지정하지 않으면 pricing_info는 가장 최신의 1개 정보만 오기 때문에, 
각 sku의 
- effectiveTime
- summary 
- pricingExpression 
- aggregationInfo
- currencyConversionRate 

필드들은 단일값을 가지는것을 알 수 있습니다. 
따라서 pricing_info의 데이터에서 summary를 제외한 4개의 필드를 추출했습니다.
(전체 데이터 확인 결과 모든 sku의 summary 값이 공백이어서 제외했습니다)
참고: https://cloud.google.com/billing/docs/reference/rest/v1/services.skus/list#PricingInfo

**2. PricingInfo 의 PricingExpression 객체의 필드들을 새로운 컬럼으로 추가**

![image](https://user-images.githubusercontent.com/72314987/181197437-9a7d1d4b-43da-45bc-ad8c-34f6b3a402fa.png)
1번에서 추출한 필드 중 pricingExpression 필드의 값은 PricingExpression 객체입니다.
따라서 해당 객체가 가지는 7개 필드를 추출하여 컬럼에 추가했습니다.
참고: https://cloud.google.com/billing/docs/reference/rest/v1/services.skus/list#PricingExpression


**3. PricingInfo의 AggregationInfo 객체의 필드들을 새로운 컬럼으로 추가**

![image](https://user-images.githubusercontent.com/72314987/181197950-7dd25db1-4241-43f3-8b45-9bc50619064c.png)
1번에서 추출한 필드 중 aggregationInfo 필드의 값은 AggregationInfo 객체입니다.
따라서 해당 객체가 가지는 3개 필드를 추출하여 컬럼에 추가했습니다.
참고: https://cloud.google.com/billing/docs/reference/rest/v1/services.skus/list#AggregationInfo

### dataframe 형성 코드 수정
위와 같이 dataframe의 컬럼을 세분화하면서 코드가 수정되었습니다.
기존 dataframe 형성 로직은 다음과 같습니다. (make_dataframe 함수)
- 반복문으로 raw data를 돌며 각 sku의 필드들 추출
- 추출된 값들을 해당하는 필드명의 리스트에 append
- 생성된 리스트들을 dataframe에 열로 추가

하지만 api가 제공하는 객체의 구조가 다소 깊어서 컬럼을 세분화 하다 보니 예외처리를 해야하는 부분이 많아졌습니다.
따라서 raw data를 컬럼별로 파싱하는 부분과 dataframe으로 합치는 부분을 함수로 분리했습니다.

**1. make_information_dict 함수 생성**
dataframe에 추가할 컬럼명 == key,  리스트 형태의 값 == value 로 가지는 dictionary를 생성합니다.
세분화가 깊게 반복적으로 이뤄지고 있다고 판단하여 해당 메소드를 사용했습니다.

**2. make_dataframe 함수 수정**
기존에 데이터를 분해하는 부분을 삭제하고 dataframe에 추가할 컬럼명과 데이터리스트 쌍을 받아 dataframe에 추가하여 반환하도록 구성했습니다.

**3. main 함수 수정**
컬럼을 세분화하면서 특히 구조가 깊은 sku의 데이터를 처리하는 과정이 길어졌습니다.
이 부분은 우선 데이터 특성 분석을 마친 후, 코드 리팩토링 작업을 통해 정리 해 보도록 하겠습니다.

### 결과
Compute Engine 대상 전체 (12875개) sku를 .pkl 파일로 저장합니다.
raw data구조와 dataframe 구조 비교 결과는 다음과 같습니다.
![image](https://user-images.githubusercontent.com/72314987/181215812-03175e27-1c15-413d-9d53-a25ef867e4ed.png)
-> summary 필드는 모든 데이터가 공백으로 들어와서 컬럼에서 제외하였습니다.
-> geoTaxonomy 필드는 serviceRegions 데이터와 동일함을 확인하여 컬럼에서 제외하였습니다. 해당 필드 내부의 "type"필드는 region의 개수에 따라 단일, 복합 으로 구분해주는 필드입니다. 현재 service region 컬럼을 리스트로 처리했기 때문에 이 부분은 큰 의미가 없다고 판단했습니다.

결과 dataframe을 csv로 공유합니다.
[gcp_price.csv](https://github.com/ddps-lab/spot-score/files/9197158/gcp_price.csv)


### 이후 진행 계획
현재까지의 코드는 Compute Engine service 범위의 sku 데이터를 로드하여 dataframe화 하는데까지 진행된 상태입니다.
이후로는 #100 이슈에서 수집한 데이터를 "compute" resource family로 추출하여 각 필드의 특성을 자세하게 분석하겠습니다.
