### PR TITLE
add workloads upload to s3

### DIFF
--- a/collection/aws/ec2_collector/workload_binpacking.py
+++ b/collection/aws/ec2_collector/workload_binpacking.py
@@ -75,7 +75,7 @@ if __name__ == "__main__":
     s3 = boto3.resource('s3')
     # need to change file location
     workloads = pickle.load(open("./workloads.pkl", "rb"))
-    s3.Object("spotlake", "monitoring/workloads.pkl").put(Body=result)
+    s3.Object("spotlake", "monitoring/workloads.pkl").put(Body=workloads)
 
     workloads = num_az_by_region()
     pickle.dump(workloads, open("./workloads", "wb"))


### PR DESCRIPTION
매일 workload를 생성할 때, 이전 시점에 생성된 로컬에 저장되어있는 workloads 파일을 S3에 업로드하고, 새롭게 생성한 workload 파일을 로컬에 저장하는 기능을 추가하였습니다.