### PR TITLE
save historical data

### DIFF
--- a/collection/aws/ec2_collector/workload_binpacking.py
+++ b/collection/aws/ec2_collector/workload_binpacking.py
@@ -78,7 +78,7 @@ if __name__ == "__main__":
     workloads = num_az_by_region()
     today = "/".join(date.today().isoformat().split("-"))
     # need to change file location
-    s3.Object("spotlake", f"monitoring/{today}/workloads.pkl").put(Body=workloads)
+    s3.Object("spotlake", f"monitoring/{today}/workloads.pkl").put(Body=pickle.dumps(workloads))
 
     result_binpacked = {}
     


### PR DESCRIPTION
#109 이슈에서 교수님께서 말씀하신 내용대로, historical하게 workload 데이터를 저장하도록 수정하였습니다.
<img width="725" alt="스크린샷 2022-08-04 오후 1 36 01" src="https://user-images.githubusercontent.com/66048830/182764371-74f8bf20-2ba0-40c5-a7f9-46603bb8f893.png">
연/월/일 디렉토리 내부에 각 날짜별 workload.pkl 파일을 저장합니다.
마찬가지로 현재 collect중인 kmubigdata 계정 내의 spotrank 시스템에도 적용해 두었습니다.
