### PR TITLE
upload rawdata, latest_json to S3 temp bucket

### DIFF
--- a/collection/gcp/upload_data.py
+++ b/collection/gcp/upload_data.py
@@ -1,0 +1,41 @@
+import boto3
+import os
+from botocore.config import Config
+from botocore.exceptions import ClientError
+
+# session = boto3.session.Session(region_name='us-west-2')
+# write_client = session.client('timestream-write', config=Config(read_timeout=20, max_pool_connections=5000, retries={'max_attempts':10}))
+
+
+BUCKET_NAME = 'tmp-gcp'
+# DATABASE_NAME = 'spotlake'
+# TABLE_NAME = 'gcp'
+LOCAL_PATH = '/home/ubuntu/spot-score/collection/gcp'
+
+# need to implement timestream upload
+
+def update_latest(data):
+    filename = 'latest_gcp.json'
+    data.to_json(f"{LOCAL_PATH}/{filename}")
+    s3_path = f'latest_data/{filename}'
+    session = boto3.Session()
+    s3 = session.client('s3')
+    with open(f"{LOCAL_PATH}/{filename}", 'rb') as f:
+        s3.upload_fileobj(f, BUCKET_NAME, s3_path)
+
+
+def save_raw(data, timestamp):
+    SAVE_FILENAME = f"{LOCAL_PATH}/spotlake_"+f"{timestamp}.csv.gz"
+    data.to_csv(SAVE_FILENAME, index=False, compression='gzip')
+    session = boto3.Session()
+    s3 = session.client('s3')
+    s3_dir_name = timestamp.strftime("%Y/%m/%d")
+    s3_obj_name = timestamp.strftime("%H:%M:%S")
+    with open(SAVE_FILENAME, 'rb') as f:
+        s3.upload_fileobj(
+            f, BUCKET_NAME, f"rawdata/{s3_dir_name}/{s3_obj_name}.csv.gz")
+
+    for filename in os.listdir(f"{LOCAL_PATH}/"):
+        if "spotlake_" in filename:
+            os.remove(f"{LOCAL_PATH}/{filename}")
+


### PR DESCRIPTION
### GCP 데이터를 주기적으로 수집하여 S3의 임시 bucket에 저장

**1. spotrank 계정의 s3에 "tmp-gcp"명의 임시 bucket을 생성하여 gcp의 주기적 수집 결과를 저장하고있습니다.**
수집 시작 시간은 한국시간 기준 9/1 오후 9시, UTC 기준 9/1 오후 12시 입니다.
수집 주기는 1시간 입니다.
<img width="2245" alt="image" src="https://user-images.githubusercontent.com/72314987/188041984-41bbcbe9-200a-4129-8aca-6847132a5d9c.png">

**2. latest json 파일도 업로드 하였습니다.** 
<img width="2241" alt="image" src="https://user-images.githubusercontent.com/72314987/188042477-38861b3a-bb3d-4001-a866-65398c781d4d.png">

저번 회의때 말씀하신대로 우선 해당 파일을 이용하여 spotlake demo 페이지에 서빙한 후, 
데이터가 모이면 데이터 변화 주기 파악과 timestream db 업로드 작업을 진행해야 할 것 같습니다.

**3. collector 셸 스크립트와 crontab**
collector.sh 파일은 후에 통합할것을 예상하여 푸시하지 않았습니다.
다음과 같은 셸 스크립트로 동작합니다.
```
#!/bin/bash

date=$(date '+%Y-%m-%dT%H:%M')

python3 /home/ubuntu/spot-score/collection/gcp/gcp_collect.py --timestamp $date
```

crontab setting 입니다
```
0 */1 * * * bash /home/ubuntu/spot-score/collection/gcp/gcp_collector.sh
```

임시 bucket의 디렉토리 구조는 spotlake bucket과 동일하게 만들었습니다.
코드상으로 bucket명과 파일 경로만 수정하면 즉시 이관 할 수 있습니다.
