### PR TITLE
GCP changed-rows 방식 저장을 위한 compare module 추가

### DIFF
--- a/collection/gcp/compare_data.py
+++ b/collection/gcp/compare_data.py
@@ -1,0 +1,75 @@
+import pandas as pd
+
+
+# compare previous collected workload with current collected workload
+# return changed workload
+def compare(previous_df, current_df, workload_cols, feature_cols):  
+    previous_df.loc[:,'Workload'] = previous_df[workload_cols].apply(lambda row: ':'.join(row.values.astype(str)), axis=1)
+    previous_df.loc[:,'Feature'] = previous_df[feature_cols].apply(lambda row: ':'.join(row.values.astype(str)), axis=1)
+    current_df.loc[:,'Workload'] = current_df[workload_cols].apply(lambda row: ':'.join(row.values.astype(str)), axis=1)
+    current_df.loc[:,'Feature'] = current_df[feature_cols].apply(lambda row: ':'.join(row.values.astype(str)), axis=1)
+
+    current_indices = current_df[['Workload', 'Feature']].sort_values(by='Workload').index
+    current_values = current_df[['Workload', 'Feature']].sort_values(by='Workload').values
+    previous_indices = previous_df[['Workload', 'Feature']].sort_values(by='Workload').index
+    previous_values = previous_df[['Workload', 'Feature']].sort_values(by='Workload').values
+    
+    changed_indices = []
+    removed_indices = []
+    
+    prev_idx = 0
+    curr_idx = 0
+    while True:
+        if (curr_idx == len(current_indices)) and (prev_idx == len(previous_indices)):
+            break
+        elif curr_idx == len(current_indices):
+            prev_workload = previous_values[prev_idx][0]
+            if prev_workload not in current_values[:,0]:
+                removed_indices.append(previous_indices[prev_idx])
+                prev_idx += 1
+                continue
+            else:
+                raise Exception('workload error')
+            break
+        elif prev_idx == len(previous_indices):
+            curr_workload = current_values[curr_idx][0]
+            curr_feature = current_values[curr_idx][1]
+            if curr_workload not in previous_values[:,0]:
+                changed_indices.append(current_indices[curr_idx])
+                curr_idx += 1
+                continue
+            else:
+                raise Exception('workload error')
+            break
+            
+        prev_workload = previous_values[prev_idx][0]
+        prev_feature = previous_values[prev_idx][1]
+        curr_workload = current_values[curr_idx][0]
+        curr_feature = current_values[curr_idx][1]
+        
+        if prev_workload != curr_workload:
+            if curr_workload not in previous_values[:,0]:
+                changed_indices.append(current_indices[curr_idx])
+                curr_idx += 1
+            elif prev_workload not in current_values[:,0]:
+                removed_indices.append(previous_indices[prev_idx])
+                prev_idx += 1
+                continue
+            else:
+                raise Exception('workload error')
+        else:
+            if prev_feature != curr_feature:
+                changed_indices.append(current_indices[curr_idx])
+            curr_idx += 1
+            prev_idx += 1
+    changed_df = current_df.loc[changed_indices].drop(['Workload', 'Feature'], axis=1)
+    removed_df = previous_df.loc[removed_indices].drop(['Workload', 'Feature'], axis=1)
+    
+    for col in feature_cols:
+        removed_df[col] = 0
+
+    # removed_df have one more column, 'Ceased'
+    removed_df['Ceased'] = True
+
+    return changed_df, removed_df
+


### PR DESCRIPTION
aws와 동일한 코드로 changed-rows 방식을 위한 compare module을 추가했고 결과를 테스트했습니다.

1. 데이터 편집 후 compare module로 테스트
GCP의 경우 아직까지 데이터의 변화가 보이지 않았습니다. 처음으로 수집한 데이터 (UTC 기준 9/1 12:00) 와 가장 마지막에 수집한 데이터를 비교했을때에도 차이가 없었습니다. 따라서 compare 모듈이 제대로 동작하는지 확인하기 위해 의도적으로 데이터를 편집하여 changed와 removed를 확인한 결과 정상적으로 작동했습니다. 테스트 코드 첨부합니다.
http://203.246.113.16:8800/notebooks/Hyeonyoung/spot-score/test_comare.ipynb
<img width="1005" alt="image" src="https://user-images.githubusercontent.com/72314987/188403665-737f6948-502c-4344-8eac-35162ed373ca.png">


2. 코드 추가 과정에서 오탈자로 인해 UTC 기준 9/5 8:00 의 수집이 제대로 이뤄지지 않아 코드 수정 후 해당 시간대의 수집을 수동으로 진행했습니다. 따라서 해당 데이터의 파일명이 08:08:00.csv.gz 입니다. bucket의 rawdata 확인 시 혼동 없으시길 바랍니다.

3. 이전 회의 결과대로 timestream upload는 보류, 일정시간 이후 gcp data의 변화 추이 파악을 진행하겠습니다. 수집 기간은 우선 2주정도로 생각중입니다.
그 사이 #171 , #125 작업을 진행하겠습니다.