### PR TITLE
[GCP] GCP metadata 변동에  따른 오류 수정

### DIFF
--- a/collection/gcp/load_pricelist.py
+++ b/collection/gcp/load_pricelist.py
@@ -174,11 +174,10 @@ def get_price(pricelist):
         for cpu_region, cpu_price in cpu_data.items():
             for ram_region, ram_price in ram_data.items():
                 for gpu_region, gpu_price in gpu_data.items():
-                    if output[machine_type][cpu_region]['ondemand'] != None:
-                        if cpu_region == ram_region and cpu_region == gpu_region and cpu_region in region_list:
+                    if cpu_region == ram_region and cpu_region == gpu_region and cpu_region in region_list:
+                        if output[machine_type][cpu_region]['ondemand'] != None:
                             output[machine_type][cpu_region]['preemptible'] = cpu_quantity * \
                                 cpu_price + ram_quantity*ram_price + gpu_quantity*gpu_price
-
     return output
 
 


### PR DESCRIPTION
S3 bucket 업데이트가 멈춰 확인해 본 결과, GCP 측 metadata가 추가됨에 따라 발생한 이슈로 확인되었습니다.

현재 코드 동작이 멈춘 원인은 a2 시리즈 머신의 경우 ondemand 가격 정보는 없지만 preemptible 가격 정보는 존재하는 경우 발생하는 문제를 해소하기 위해 작성했던 코드에서 metadata에 정의되지 않은 key를 참조하고 있기 때문이었습니다.
간단히 조건문의 순서를 바꾸어 줌으로써 우선 정상동작 하도록 만들었습니다.

다만, 이번 문제는 이전부터 metadata 기정의 문제로 인지되어왔고, 생각보다 문제 발생이 빠르게 일어나 해결해야 할 것 같습니다.
자세한 변동 사항 정보는 #188  에서 다루도록 하겠습니다.