### PR TITLE
Nearly complete creating query_string function

### DIFF
--- a/data-release/api-lambda/spotlake-timestream-query.py
+++ b/data-release/api-lambda/spotlake-timestream-query.py
@@ -211,27 +211,27 @@ def _parse_column_name(info):
         return ""
 
 def lambda_handler(event, context):
-    operation = event['requestContext']['http']['method']
-    if operation != 'GET':
-        return {
-            'statusCode': 200,
-            'headers': {
-                'Access-Control-Allow-Headers': '*',
-                'Access-Control-Allow-Origin': 'https://spotlake.ddps.cloud',
-                'Access-Control-Allow-Methods': 'OPTIONS,GET'
-            },
-            'body': json.dumps("[]")
-        }
-    if (not 'origin' in event['headers']) or event['headers']['origin'] != 'https://spotlake.ddps.cloud':
-        return {
-            'statusCode': 200,
-            'headers': {
-                'Access-Control-Allow-Headers': '*',
-                'Access-Control-Allow-Origin': 'https://spotlake.ddps.cloud',
-                'Access-Control-Allow-Methods': 'OPTIONS,GET'
-            },
-            'body': json.dumps("[]")
-        }
+    '''
+    
+    
+    
+    
+    
+    
+    
+    
+    Filtering Code
+    CORS,
+    http method,
+    etc...
+    
+    
+    
+    
+    
+    
+    
+    '''
     info = event['queryStringParameters']
     table_name = info['TableName']
     start = info['Start']


### PR DESCRIPTION
주어진 table_name에 따라 다른 쿼리문을 작성하도록 하는 함수의 작성을 완료했습니다.
#170 , #89 이슈입니다.

## aws
### Query Parameters
* TableName : aws
* InstanceType
* Region
* AZ
* Start
* End

### Returned Data
* id
* Ceased
* OndemandPrice
* AZ
* Region
* InstanceType
* time
* SpotPrice
* SPS
* IF

### 이벤트 Json 예시
```
{
  "headers": {
      "origin": "https://spotlake.ddps.cloud"
  },
  "requestContext": {
      "http": {
          "method": "GET"
      }
  },
  "queryStringParameters": {
      "TableName": "aws",
      "InstanceType": "a1.large",
      "Region": "us-east-1",
      "AZ": "*",
      "Start": "2022-09-28",
      "End": "2022-09-29"
  }
}
```

## gcp
### Query Parameters
* TableName : gcp
* InstanceType
* Region
* Start
* End

### Returned Data
* id
* Ceased
* InstanceType
* Region
* Calculator OnDemand Price
* Calculator Preemptible Price
* Calculator Savings
* VM Instance OnDemand Price
* VM Instance Preemptible Price
* VM Instance Savings
* time

### 이벤트 Json 예시
```
{
  "headers": {
      "origin": "https://spotlake.ddps.cloud"
  },
  "requestContext": {
      "http": {
          "method": "GET"
      }
  },
  "queryStringParameters": {
      "TableName": "gcp",
      "InstanceType": "a2-highgpu-1g",
      "Region": "asia-northeast1",
      "Start": "2022-09-28",
      "End": "2022-09-29"
  }
}
```

## azure
### Query Parameters
* TableName : azure
* InstanceType
* InstanceTier
* Region
* Start
* End

### Returned Data
* id
* Ceased
* InstanceTier
* InstanceType
* location
* ondemandPrice
* spotPrice
* savings

### 이벤트 Json 예시
```
{
  "headers": {
      "origin": "https://spotlake.ddps.cloud"
  },
  "requestContext": {
      "http": {
          "method": "GET"
      }
  },
  "queryStringParameters": {
      "TableName": "azure",
      "InstanceTier": "Basic",
      "InstanceType": "A0",
      "Region": "AP East",
      "Start": "2022-09-28",
      "End": "2022-09-29"
  }
}
```

## 추가적으로 개발해야하는 내용
gcp, azure와 같은 경우에는, 아직 timestream spotlake DB에 데이터를 저장하고 있지 않으므로, 저장을 시작한 이후 query문의 추가적인 수정이 필요할 수 있습니다.
특히 gcp와 같은 경우에는 Calculator, VM Instance로 두개의 정보를 저장하고 있기 때문에, 이에 대응할 수 있도록 수정이 필요합니다.