### PR TITLE
remove Vendor, Savings column and savings calculate process

### DIFF
--- a/collection/gcp/gcp_collect.py
+++ b/collection/gcp/gcp_collect.py
@@ -56,9 +56,9 @@ df_vminstance_pricing = pd.DataFrame(output_vminstance_pricing)
 
 # preprocessing
 df_pricelist = pd.DataFrame(preprocessing_price(df_pricelist), columns=[
-    'Vendor', 'InstanceType', 'Region', 'Calculator OnDemand Price', 'Calculator Preemptible Price', 'Calculator Savings'])
+    'InstanceType', 'Region', 'Calculator OnDemand Price', 'Calculator Preemptible Price'])
 df_vminstance_pricing = pd.DataFrame(preprocessing_price(df_vminstance_pricing), columns=[
-    'Vendor', 'InstanceType', 'Region', 'VM Instance OnDemand Price', 'VM Instance Preemptible Price', 'VM Instance Savings'])
+    'InstanceType', 'Region', 'VM Instance OnDemand Price', 'VM Instance Preemptible Price'])
 
 
 # make final dataframe
@@ -83,4 +83,5 @@ feature_cols = ['Calculator OnDemand Price', 'Calculator Preemptible Price', 'VM
 changed_df, removed_df = compare(df_previous, df_current, workload_cols, feature_cols)
 
 # need to upload timestream
+
 

--- a/collection/gcp/load_pricelist.py
+++ b/collection/gcp/load_pricelist.py
@@ -184,20 +184,18 @@ def get_price(pricelist):
 def preprocessing_price(df):
     # make list to struct final dataframe
     # input : dataframe 
-    # output : list having Vendor, Instance type, Region, Ondemand price, Preemptible price, Savings
+    # output : list having Instance type, Region, Ondemand price, Preemptible price
     
     new_list = []
     for machine_type, info in df.items():
         for region, price in info.items():
             ondemand = price['ondemand']
             preemptible = price['preemptible']
-            savings = None
 
             if ondemand != None and preemptible != None:
                 ondemand = round(ondemand, 4)
                 preemptible = round(preemptible, 4)
-                savings = int(round((ondemand - preemptible) / ondemand * 100))
 
             new_list.append(
-                ['Google', machine_type, region, ondemand, preemptible, savings])
+                 [machine_type, region, ondemand, preemptible])
     return new_list


### PR DESCRIPTION
회의 결과 Vendor를 삭제하고, Savings 를 프론트 단에서 계산하여 제공하기로 결정되었습니다.
변경 사항은 다음과 같습니다.

- Vendor column 삭제
- Savings column 삭제
- Savings 계산 과정 삭제

변경된 데이터 셋 구성입니다.
<img width="888" alt="image" src="https://user-images.githubusercontent.com/72314987/191399049-03c1d189-f908-444e-ab36-739780a37eb1.png">

