### PR TITLE
build된 파일 업로드하도록 github action 경로 변경

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - 'main'
     paths:
-      - 'frontend/public/**'
+      - 'frontend/build/**'
   workflow_dispatch:
       
 env:


### PR DESCRIPTION
build된 frontend 파일들을 frontend/build에 push하도록 의견을 조율함.
때문에 github action의 트리거가 되는 경로를 변경