### PR TITLE
Add creating invalidation step

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -20,3 +20,5 @@ jobs:
       - uses: actions/checkout@v2
       - name: "Sync with AWS S3"
         run: aws s3 sync ./frontend/build/ s3://${{ secrets.AWS_SPOTLAKE_S3_BUCKET_NAME }} --acl public-read --delete
+      - name: "Create Invalidation"
+        run: aws cloudfront create-invalidation --distribution-id EM3KPE8H4PYYF --paths "/*"


### PR DESCRIPTION
spotlake.ddps.cloud 배포 파일 갱신 시, cloudfront에도 바로 적용이 이루어지도록 invalidation 작성