### PR TITLE
fix get iframe url

### DIFF
--- a/collector/spot-dataset/gcp/load_vminstance_pricing.py
+++ b/collector/spot-dataset/gcp/load_vminstance_pricing.py
@@ -18,8 +18,13 @@ def get_url_list(page_url):
         iframe_list = soup.select('devsite-iframe')
 
         for iframe in iframe_list:
-            url_list.append(iframe.select_one(
-                'iframe').get_attribute_list('src')[0])
+            url = iframe.select_one(
+                'iframe').get_attribute_list('src')[0]
+            
+            if url.find('https://cloud.google.com') == -1:
+                url = 'https://cloud.google.com' + url
+            url_list.append(url)
+
     else:
         logging.error(response.status_code)
 
@@ -31,7 +36,7 @@ def get_table(url):
     # input : url of iframe
     # output : table
 
-    response = requests.get('https://cloud.google.com' + url)
+    response = requests.get(url)
     if response.status_code == 200:
         html = response.text
         soup = BeautifulSoup(html, 'html.parser')


### PR DESCRIPTION
#338 에서 GCP 수집 모듈이 중단되었고, 원인 파악 결과 기존에 html 에서 얻어온 iframe 의 attribute 값이 변경되었기 때문임을 확인했습니다.
이에 따라 `'https://cloud.google.com' + url` 로 request를 보내는 방식에서  url 로만 request를 보내도록 수정했습니다.

이같은 일이 또 발생할 수도 있어서, 얻어온 attribute 값에 `https://cloud.google.com'` 가 존재하는지 확인 후, 존재하지 않으면 `https://cloud.google.com' + url` 로 가공하여 반환하도록 변경했습니다. 
다만, 이 방법도 하드코딩 방식이기 때문에 만약  iframe url이 새로운 방식으로 제공된다면 코드 수정이 불가피 할 거 같습니다. 

다른 좋은 방법이 있는지 의논이 필요하며, 신속하게 gcp 수집 모듈의 에러 발생 현황을 보고하는 시스템 구현이 필요한 것 같습니다.