### PR TITLE
AWS Collector refactoring

### DIFF
--- a/collector/spot-dataset/aws/ec2_collector/aws_collect.py
+++ b/collector/spot-dataset/aws/ec2_collector/aws_collect.py
@@ -16,7 +16,7 @@ from upload_data import upload_timestream, update_latest, save_raw
 from join_data import build_join_df
 
 NUM_CPU = 2
-LOCAL_PATH = '/home/ubuntu/spot-score/collection/aws/ec2_collector'
+LOCAL_PATH = '/home/ubuntu/spotlake/collector/spot-dataset/aws/ec2_collector'
 
 # get timestamp from argument
 parser = argparse.ArgumentParser()
@@ -26,7 +26,7 @@ timestamp = datetime.strptime(args.timestamp, "%Y-%m-%dT%H:%M")
 date = args.timestamp.split("T")[0]
 
 # need to change file location
-workload = get_binpacked_workload(date)
+workload = pickle.load(open(f"{LOCAL_PATH}/workload.pkl", "rb"))
 credentials = pickle.load(open(f'{LOCAL_PATH}/user_cred_df_100_199.pkl', 'rb'))
 
 mp_workload = []

--- a/collector/spot-dataset/aws/ec2_collector/load_price.py
+++ b/collector/spot-dataset/aws/ec2_collector/load_price.py
@@ -11,7 +11,7 @@ from load_metadata import get_regions
 
 
 BUCKET_NAME = 'spotlake'
-LOCAL_PATH = '/home/ubuntu/spot-score/collection/aws/ec2_collector'
+LOCAL_PATH = '/home/ubuntu/spotlake/collector/spot-dataset/aws/ec2_collector'
 
 
 # get spot price by all availability zone in single region

--- a/collector/spot-dataset/aws/ec2_collector/load_spotinfo.py
+++ b/collector/spot-dataset/aws/ec2_collector/load_spotinfo.py
@@ -4,7 +4,7 @@ import pickle
 import subprocess
 
 
-LOCAL_PATH = '/home/ubuntu/spot-score/collection/aws/ec2_collector'
+LOCAL_PATH = '/home/ubuntu/spotlake/collector/spot-dataset/aws/ec2_collector'
 
 
 # get info of interrupt frequency at spotinfo

--- a/collector/spot-dataset/aws/ec2_collector/upload_data.py
+++ b/collector/spot-dataset/aws/ec2_collector/upload_data.py
@@ -14,7 +14,7 @@ write_client = session.client('timestream-write', config=Config(read_timeout=20,
 BUCKET_NAME = 'spotlake'
 DATABASE_NAME = 'spotlake'
 TABLE_NAME = 'aws'
-LOCAL_PATH = '/home/ubuntu/spot-score/collection/aws/ec2_collector'
+LOCAL_PATH = '/home/ubuntu/spotlake/collector/spot-dataset/aws/ec2_collector'
 
 
 # Submit Batch To Timestream
@@ -96,7 +96,7 @@ def save_raw(data, timestamp):
     session = boto3.Session()
     s3 = session.client('s3')
     s3_dir_name = timestamp.strftime("%Y/%m/%d")
-    s3_obj_name = timestamp.strftime("%H:%M:%S")
+    s3_obj_name = timestamp.strftime("%H-%M-%S")
 
     with open(SAVE_FILENAME, 'rb') as f:
         s3.upload_fileobj(f, BUCKET_NAME, f"rawdata/aws/{s3_dir_name}/{s3_obj_name}.csv.gz")

--- a/collector/spot-dataset/aws/ec2_collector/workload_binpacking.py
+++ b/collector/spot-dataset/aws/ec2_collector/workload_binpacking.py
@@ -5,13 +5,14 @@ import boto3
 import pickle
 import os
 import gzip
+import argparse
 from ortools.linear_solver import pywraplp
 from load_metadata import num_az_by_region
 from utility import slack_msg_sender
 
 
 BUCKET_NAME = "spotlake"
-LOCAL_PATH = "/home/ubuntu/spot-score/collection/aws/ec2_collector"
+LOCAL_PATH = "/home/ubuntu/spotlake/collector/spot-dataset/aws/ec2_collector"
 
 
 # create object of bin packing input data
@@ -130,3 +131,14 @@ def get_binpacked_workload(filedate):
     pickle.dump(user_cred, open(f"{LOCAL_PATH}/user_cred_df_100_199.pkl", "wb"))
 
     return user_queries_list
+
+if __name__=="__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--timestamp', dest='timestamp', action='store')
+    args = parser.parse_arg()
+    timestamp = datetime.strptime(args.timestamp, "%Y-%m-%dT%H:%M")
+    date = args.timestamp.split("T")[0]
+
+    workload = get_binpacked_workload(date)
+    pickle.dump(workload, open(f"{LOCAL_PATH}/workload.pkl", "wb"))
+


### PR DESCRIPTION
### workload 생성 코드와 collect 코드가 별개로 돌아가도록 구성
workload 생성 코드는 worklaod 생성 후 workload.pkl 이름으로 로컬에 저장
collect 코드는 로컬에 저장된 workload.pkl 파일을 사용하여 데이터 수집

### LOCAL_PATH 수정
그동안은 수정된 코드를 ec2에서 수작업으로 수정하여 반영하여서, spot-score가 spotlake로 바뀌는 등의 경로 변경에 문제가 없었지만,
이번에 auto recovery 기능을 활성화하기 위해 새롭게 환경을 세팅할 예정이므로, LOCAL_PATH를 현재의 레포지토리 환경에 걸맞게 변경

### upload name 수정
S3에 업로드되는 raw data의 이름에 : 대신 -가 사용되도록 변경