### PR TITLE
Azure collector fix duplicate, nan handling

### DIFF
--- a/collector/spot-dataset/azure/compare_data.py
+++ b/collector/spot-dataset/azure/compare_data.py
@@ -15,6 +15,9 @@ def compare(previous_df, current_df, workload_cols, feature_cols):
     current_df.loc[:, 'Workload'] = current_df[workload_cols].apply(lambda row: ':'.join(row.values.astype(str)), axis=1)
     current_df.loc[:, 'Feature'] = current_df[feature_cols].apply(lambda row: ':'.join(row.values.astype(str)), axis=1)
 
+    previous_df = previous_df.drop_duplicates(['Workload'])
+    current_df = current_df.drop_duplicates(['Workload'])
+
     current_indices = current_df[['Workload', 'Feature']].sort_values(by='Workload').index
     current_values = current_df[['Workload', 'Feature']].sort_values(by='Workload').values
     previous_indices = previous_df[['Workload', 'Feature']].sort_values(by='Workload').index


### PR DESCRIPTION
Azure collector compare모듈에서 중복처리 문제가 발생하였습니다.

<img width="816" alt="Screenshot 2022-12-08 at 11 22 26 PM" src="https://user-images.githubusercontent.com/106056971/206598782-46579c08-e446-4375-b58f-0021d2d58f55.png">

위 사진은 동일한 데이터지만 id컬럼의 값이 달라 compare모듈에서 중복으로 인지하지 않고 값을 삭제하지 않아 발생한 에러였습니다.

중복값을 InstanceTier-InstanceeType-Region쌍으로 제거하고 nan값을 -1로 치환하는 코드를 추가하였습니다.