### PR TITLE
인스턴스 코어마크를 측정하고 s3에 결과값을 올리는 스크립트

### DIFF
--- a/utility/coremark_measuring_instrument.py
+++ b/utility/coremark_measuring_instrument.py
@@ -12,11 +12,12 @@ AWS_SECRET_ACCESS_KEY = credentials.secret_key
 
 # x86 ami
 ami = 'ami-0a65996d2713f71f1'
+ami_arm = 'ami-0f5eb0adc5237861b'
 
 instance_type = 'c4.xlarge'
 BUCKET_NAME = 'instance-coremark-result'
 result_file = f'{instance_type}_coremark_result.txt'
-core_num = 4
+#core_num = 4
 
 userdata = f'''#!/bin/bash
 apt-get update -y
@@ -33,13 +34,15 @@ cd coremark/
 
 touch {result_file}
 
-make XCFLAGS="-DMULTITHREAD={core_num} -DUSE_PTHREAD -pthread" REBUILD=1
+core_num=$(lscpu | grep -m 1 "CPU(s)" | cut -d ':' -f 2 | sed 's/ //g')
+
+make XCFLAGS="-DMULTITHREAD=$core_num -DUSE_PTHREAD -pthread" REBUILD=1
 cat run1.log | grep "CoreMark 1.0" >> {result_file}
 
-make XCFLAGS="-DMULTITHREAD={core_num} -DUSE_PTHREAD -pthread" REBUILD=1
+make XCFLAGS="-DMULTITHREAD=$core_num -DUSE_PTHREAD -pthread" REBUILD=1
 cat run1.log | grep "CoreMark 1.0" >> {result_file}
 
-make XCFLAGS="-DMULTITHREAD={core_num} -DUSE_PTHREAD -pthread" REBUILD=1
+make XCFLAGS="-DMULTITHREAD=$core_num -DUSE_PTHREAD -pthread" REBUILD=1
 cat run1.log | grep "CoreMark 1.0" >> {result_file}
 
 aws s3 cp {result_file} s3://{BUCKET_NAME}/


### PR DESCRIPTION
현재는 x86 계열의 인스턴스 타입과 코어마크 개수를 설정하면 해당 인스턴스의 코어마크 점수를 측정하고 그 결과값을 s3 instance-coremark-result 버킷에 저장하도록 구현하였습니다. 여기에 arm계열의 인스턴스도 측정이 가능하게 하고 동시에 여러 인스턴스 타입을 측정하도록 파일형태로 입력을 받도록 변경할 예정입니다. 거기에 cpu가 arm 계열인지 x86 계열인지와 코어개수를 lscpu로 얻어오도록 할 생각입니다.