### PR TITLE
github action을 이용한 lambda 코드 연동

### DIFF
--- a/.github/workflows/azure-lambda-sync.yml
+++ b/.github/workflows/azure-lambda-sync.yml
@@ -1,0 +1,29 @@
+name: deploy to lambda
+on:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - 'collector/spot-dataset/gcp/lambda/**'
+      - 'utility/slack_msg_sender.py'
+      - 'const_config.py'
+
+env:
+  AWS_ACCESS_KEY_ID: ${{ secrets.SPOTRANK_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.SPOTRANK_SECRET_ACCESS_KEY }}
+  AWS_DEFAULT_REGION: 'us-west-2'
+
+jobs:
+  deploy_source:
+    name: deploy lambda from source
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout source code
+        uses: actions/checkout@v1
+      - name: Zip lambda_function code
+        run: |
+          zip -r gcp_lambda.zip ./utility/slack_msg_sender.py
+          zip -j gcp_lambda.zip ./collector/spot-dataset/gcp/lambda/* ./const_config.py
+      - name: Deploy to lambda
+        run: |
+          aws lambda update-function-code --function-name gcp-collector --zip-file fileb://gcp_lambda.zip

--- a/.github/workflows/azure-lambda-sync.yml
+++ b/.github/workflows/azure-lambda-sync.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - 'main'
     paths:
-      - 'collector/spot-dataset/gcp/lambda/**'
+      - 'collector/spot-dataset/azure/lambda/current_collector/**'
       - 'utility/slack_msg_sender.py'
       - 'const_config.py'
 
@@ -22,8 +22,11 @@ jobs:
         uses: actions/checkout@v1
       - name: Zip lambda_function code
         run: |
-          zip -r gcp_lambda.zip ./utility/slack_msg_sender.py
-          zip -j gcp_lambda.zip ./collector/spot-dataset/gcp/lambda/* ./const_config.py
+          zip -j ./collector/spot-dataset/azure/lambda/current_collector/azure_lambda.zip ./collector/spot-dataset/azure/lambda/current_collector/* ./const_config.py ./utility/slack_msg_sender.py
+          cd ./collector/spot-dataset/azure/lambda/current_collector/
+          zip -r azure_lambda.zip ./utill/*
+          cd ../../../../../
+          mv ./collector/spot-dataset/azure/lambda/current_collector/azure_lambda.zip ./
       - name: Deploy to lambda
         run: |
-          aws lambda update-function-code --function-name gcp-collector --zip-file fileb://gcp_lambda.zip
+          aws lambda update-function-code --function-name azure-collector --zip-file fileb://azure_lambda.zip

--- a/.github/workflows/gcp-lambda-sync.yml
+++ b/.github/workflows/gcp-lambda-sync.yml
@@ -1,0 +1,29 @@
+name: deploy to lambda
+on:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - 'collector/spot-dataset/gcp/lambda/**'
+      - 'utility/slack_msg_sender.py'
+      - 'const_config.py'
+
+env:
+  AWS_ACCESS_KEY_ID: ${{ secrets.SPOTRANK_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.SPOTRANK_SECRET_ACCESS_KEY }}
+  AWS_DEFAULT_REGION: 'us-west-2'
+
+jobs:
+  deploy_source:
+    name: deploy lambda from source
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout source code
+        uses: actions/checkout@v1
+      - name: Zip lambda_function code
+        run: |
+          zip -r gcp_lambda.zip ./utility/slack_msg_sender.py
+          zip -j gcp_lambda.zip ./collector/spot-dataset/gcp/lambda/* ./const_config.py
+      - name: Deploy to lambda
+        run: |
+          aws lambda update-function-code --function-name gcp-collector --zip-file fileb://gcp_lambda.zip


### PR DESCRIPTION
azure와 gcp collector에 변경이 일어났을 때, github에 업데이트하면 자동으로 collector lambda에도 연동이 될 수 있도록 github action을 작성

azure의 경우,
collector/spot-dataset/azure/lambda/current_collector/ 내부에 존재하는 파일들,
utility/slack_msg_sender.py
const_config.py
를 하나의 zip파일로 압축하여 이를 lambda에 업로드

gcp의 경우,
collector/spot-dataset/azure/lambda/current_collector/ 내부에 존재하는 파일들,
utility/slack_msg_sender.py
const_config.py
를 하나의 zip파일로 압축하여 이를 lambda에 업로드