### PR TITLE
Code update to prepare interruptions

### DIFF
--- a/collector/spot-dataset/aws/ec2_collector/aws_collect.py
+++ b/collector/spot-dataset/aws/ec2_collector/aws_collect.py
@@ -44,7 +44,7 @@ try:
     workload = pickle.load(gzip.open(s3.Object(STORAGE_CONST.BUCKET_NAME, f'rawdata/aws/workloads/{"/".join(date.split("-"))}/binpacked_workloads.pkl.gz').get()['Body']))
 except Exception as e:
     send_slack_message(e)
-    workload = pickle.load(open(f"{AWS_CONST.LOCAL_PATH}/workloads.pkl", "rb"))
+    workload = pickle.load(s3.Object(STORAGE_CONST.BUCKET_NAME, f'rawdata/aws/localfile/workloads.pkl').get()['Body'])
 
 credentials = None
 try:

--- a/collector/spot-dataset/aws/ec2_collector/aws_collect.py
+++ b/collector/spot-dataset/aws/ec2_collector/aws_collect.py
@@ -46,9 +46,9 @@ try:
 except Exception as e:
     send_slack_message(e)
     try :
-        workload = pickle.load(s3.Object(STORAGE_CONST.BUCKET_NAME, f'{AWS_CONST.S3_LOCAL_FILES_SAVE_PATH}/workloads.pkl').get()['Body'])
-    except:
         workload = pickle.load(open(f'{AWS_CONST.LOCAL_PATH}/workloads.pkl', 'rb'))
+    except:
+        workload = pickle.load(s3.Object(STORAGE_CONST.BUCKET_NAME, f'{AWS_CONST.S3_LOCAL_FILES_SAVE_PATH}/workloads.pkl').get()['Body'])
 
 credentials = None
 try:

--- a/collector/spot-dataset/aws/ec2_collector/aws_collect.py
+++ b/collector/spot-dataset/aws/ec2_collector/aws_collect.py
@@ -46,7 +46,11 @@ except Exception as e:
     send_slack_message(e)
     workload = pickle.load(open(f"{AWS_CONST.LOCAL_PATH}/workloads.pkl", "rb"))
 
-credentials = pickle.load(open(f'{AWS_CONST.LOCAL_PATH}/user_cred_df_100_199.pkl', 'rb'))
+credentials = None
+try:
+    credentials = pickle.load(open(f'{AWS_CONST.LOCAL_PATH}/user_cred_df_100_199.pkl', 'rb'))
+except:
+    credentials = pickle.load(s3.Object(STORAGE_CONST.BUCKET_NAME, f'rawdata/aws/localfile/user_cred_df.pkl').get()['Body'])
 
 mp_workload = []
 for i in range(len(workload)):
@@ -84,22 +88,26 @@ try:
 except Exception as e:
     send_slack_message(e)
 
+if 'latest_df.pkl' not in os.listdir(f'{AWS_CONST.LOCAL_PATH}/'):
+    try:
+        previous_df = pickle.load(s3.Object(STORAGE_CONST.BUCKET_NAME, 'rawdata/aws/localfile/latest_df.pkl').get()['Body'])
+        pickle.dump(previous_df, open(f"{AWS_CONST>LOCAL_PATH}/latest_df.pkl", "rb"))
+    except:
+        pickle.dump(current_df, open(f"{AWS_CONST.LOCAL_PATH}/latest_df.pkl", "wb"))
+        try:
+            upload_timestream(current_df, timestamp)
+        except Exception as e:
+            send_slack_message(e)
+        exit()
+
+previous_df = pickle.load(open(f"{AWS_CONST.LOCAL_PATH}/latest_df.pkl", "rb")) # load previous data from local file system
+pickle.dump(current_df, open(f"{AWS_CONST.LOCAL_PATH}/latest_df.pkl", "wb")) # write current data to local file system
+
 try:
     update_latest(current_df, timestamp) # upload current data to S3
     save_raw(current_df, timestamp)
 except Exception as e:
     send_slack_message(e)
-
-if 'latest_df.pkl' not in os.listdir(f'{AWS_CONST.LOCAL_PATH}/'):
-    pickle.dump(current_df, open(f"{AWS_CONST.LOCAL_PATH}/latest_df.pkl", "wb"))
-    try:
-        upload_timestream(current_df, timestamp)
-    except Exception as e:
-        send_slack_message(e)
-    exit()
-
-previous_df = pickle.load(open(f"{AWS_CONST.LOCAL_PATH}/latest_df.pkl", "rb")) # load previous data from local file system
-pickle.dump(current_df, open(f"{AWS_CONST.LOCAL_PATH}/latest_df.pkl", "wb")) # write current data to local file system
 
 workload_cols = ['InstanceType', 'Region', 'AZ']
 feature_cols = ['SPS', 'IF', 'SpotPrice', 'OndemandPrice']

--- a/collector/spot-dataset/aws/ec2_collector/aws_collect.py
+++ b/collector/spot-dataset/aws/ec2_collector/aws_collect.py
@@ -98,7 +98,7 @@ try:
     try:
         previous_df = pd.DataFrame(json.load(open(f"{AWS_CONST.LOCAL_PATH}/latest_aws.json", "r")))
     except:
-        previous_df = pd.DataFrame(json.load(s3.Object(STORAGE_CONST.BUCKET_NAME, f'latset_data/latest_aws.json').get()['Body'].read()))
+        previous_df = pd.DataFrame(json.load(s3.Object(STORAGE_CONST.BUCKET_NAME, f'{AWS_CONST.S3_LATEST_DATA_SAVE_PATH}').get()['Body'].read()))
     previous_df = previous_df.drop(columns=['id', 'time'])
 except:
     update_latest(current_df, timestamp)

--- a/collector/spot-dataset/aws/ec2_collector/aws_collect.py
+++ b/collector/spot-dataset/aws/ec2_collector/aws_collect.py
@@ -95,7 +95,11 @@ except Exception as e:
 
 previous_df = None
 try:
-    previous_df = pd.DataFrame(json.load(s3.Object(STORAGE_CONST.BUCKET_NAME, f'{AWS_CONST.S3_LATEST_DATA_SAVE_PATH}').get()['Body'].read()))
+    try:
+        previous_df = pd.DataFrame(json.load(open(f"{AWS_CONST.LOCAL_PATH}/latest_aws.json", "r")))
+    except:
+        previous_df = pd.DataFrame(json.load(s3.Object(STORAGE_CONST.BUCKET_NAME, f'latset_data/latest_aws.json').get()['Body'].read()))
+    previous_df = previous_df.drop(columns=['id', 'time'])
 except:
     update_latest(current_df, timestamp)
     try:

--- a/collector/spot-dataset/aws/ec2_collector/aws_collect.py
+++ b/collector/spot-dataset/aws/ec2_collector/aws_collect.py
@@ -40,11 +40,15 @@ timestamp = datetime.strptime(args.timestamp, "%Y-%m-%dT%H:%M")
 date = args.timestamp.split("T")[0]
 
 # need to change file location
+workload = None
 try:
     workload = pickle.load(gzip.open(s3.Object(STORAGE_CONST.BUCKET_NAME, f'{AWS_CONST.S3_WORKLOAD_SAVE_PATH}/{"/".join(date.split("-"))}/binpacked_workloads.pkl.gz').get()['Body']))
 except Exception as e:
     send_slack_message(e)
-    workload = pickle.load(s3.Object(STORAGE_CONST.BUCKET_NAME, f'{AWS_CONST.S3_LOCAL_FILES_SAVE_PATH}/workloads.pkl').get()['Body'])
+    try :
+        workload = pickle.load(s3.Object(STORAGE_CONST.BUCKET_NAME, f'{AWS_CONST.S3_LOCAL_FILES_SAVE_PATH}/workloads.pkl').get()['Body'])
+    except:
+        workload = pickle.load(open(f'{AWS_CONST.LOCAL_PATH}/workloads.pkl', 'rb'))
 
 credentials = None
 try:
@@ -84,14 +88,12 @@ except Exception as e:
     send_slack_message(e)
 
 current_df = None
-
 try:
     current_df = build_join_df(spot_price_df, ondemand_price_df, spotinfo_df, sps_df)
 except Exception as e:
     send_slack_message(e)
 
 previous_df = None
-
 try:
     previous_df = pd.DataFrame(json.load(s3.Object(STORAGE_CONST.BUCKET_NAME, f'{AWS_CONST.S3_LATEST_DATA_SAVE_PATH}').get()['Body'].read()))
 except:

--- a/collector/spot-dataset/aws/ec2_collector/aws_collect.py
+++ b/collector/spot-dataset/aws/ec2_collector/aws_collect.py
@@ -83,10 +83,14 @@ try:
 except Exception as e:
     send_slack_message(e)
 
+current_df = None
+
 try:
     current_df = build_join_df(spot_price_df, ondemand_price_df, spotinfo_df, sps_df)
 except Exception as e:
     send_slack_message(e)
+
+previous_df = None
 
 try:
     previous_df = pd.DataFrame(json.load(s3.Object(STORAGE_CONST.BUCKET_NAME, f'{AWS_CONST.S3_LATEST_DATA_SAVE_PATH}').get()['Body'].read()))

--- a/collector/spot-dataset/aws/ec2_collector/upload_data.py
+++ b/collector/spot-dataset/aws/ec2_collector/upload_data.py
@@ -83,6 +83,8 @@ def update_latest(data, timestamp):
     s3 = session.client('s3')
     with open(f"{AWS_CONST.LOCAL_PATH}/{filename}", 'rb') as f:
         s3.upload_fileobj(f, STORAGE_CONST.BUCKET_NAME, s3_path)
+    with open(f"{AWS_CONST.LOCAL_PATH}/latest_df.pkl", 'rb') as f:
+        s3.upload_fileobj(f, STORAGE_CONST.BUCKET_NAME, 'rawdata/aws/localfile/latest_df.pkl')
     s3 = session.resource('s3')
     object_acl = s3.ObjectAcl(STORAGE_CONST.BUCKET_NAME, s3_path)
     response = object_acl.put(ACL='public-read')

--- a/collector/spot-dataset/aws/ec2_collector/upload_data.py
+++ b/collector/spot-dataset/aws/ec2_collector/upload_data.py
@@ -74,7 +74,6 @@ def upload_timestream(data, timestamp):
 
 def update_latest(data, timestamp):
     filename = 'latest_aws.json'
-    data = data.drop(data[(data['AZ'].isna()) | (data['Region'].isna()) | (data['InstanceType'].isna())].index)
     data['time'] = timestamp.strftime("%Y-%m-%d %H:%M:%S")
     data['id'] = data.index+1
     result = data.to_json(f"{AWS_CONST.LOCAL_PATH}/{filename}", orient="records")
@@ -83,8 +82,6 @@ def update_latest(data, timestamp):
     s3 = session.client('s3')
     with open(f"{AWS_CONST.LOCAL_PATH}/{filename}", 'rb') as f:
         s3.upload_fileobj(f, STORAGE_CONST.BUCKET_NAME, s3_path)
-    with open(f"{AWS_CONST.LOCAL_PATH}/latest_df.pkl", 'rb') as f:
-        s3.upload_fileobj(f, STORAGE_CONST.BUCKET_NAME, 'rawdata/aws/localfile/latest_df.pkl')
     s3 = session.resource('s3')
     object_acl = s3.ObjectAcl(STORAGE_CONST.BUCKET_NAME, s3_path)
     response = object_acl.put(ACL='public-read')

--- a/collector/spot-dataset/aws/ec2_collector/workload_binpacking.py
+++ b/collector/spot-dataset/aws/ec2_collector/workload_binpacking.py
@@ -92,9 +92,9 @@ def get_binpacked_workload(filedate):
     # reverse order of credential data
     user_cred = None
     try:
-        user_cred = pickle.load(s3.Object(STORAGE_CONST.BUCKET_NAME, f'{AWS_CONST.S3_LOCAL_FILES_SAVE_PATH}/user_cred_df.pkl').get()['Body'])
-    except:
         user_cred = pickle.load(open(f"{AWS_CONST.LOCAL_PATH}/user_cred_df.pkl", "rb"))
+    except:
+        user_cred = pickle.load(s3.Object(STORAGE_CONST.BUCKET_NAME, f'{AWS_CONST.S3_LOCAL_FILES_SAVE_PATH}/user_cred_df.pkl').get()['Body'])
     user_cred = user_cred[::-1]
     pickle.dump(user_cred, open(f"{AWS_CONST.LOCAL_PATH}/user_cred_df.pkl", "wb"))
     with open(f"{AWS_CONST.LOCAL_PATH}/user_cred_df.pkl", 'rb') as f:

--- a/collector/spot-dataset/aws/ec2_collector/workload_binpacking.py
+++ b/collector/spot-dataset/aws/ec2_collector/workload_binpacking.py
@@ -153,5 +153,7 @@ if __name__=="__main__":
         workload = get_binpacked_workload(date)
     except botocore.exceptions.ClientError as e:
         send_slack_message(e)
+    s3_client = boto3.client('s3')
     pickle.dump(workload, open(f"{AWS_CONST.LOCAL_PATH}/workloads.pkl", "wb"))
+    s3_client.upload_fileobj(open(f"{AWS_CONST.LOCAL_PATH}/workloads.pkl", "rb"), STORAGE_CONST.BUCKET_NAME, f"rawdata/aws/localfile/workloads.pkl")
 

--- a/collector/spot-dataset/aws/ec2_collector/workload_binpacking.py
+++ b/collector/spot-dataset/aws/ec2_collector/workload_binpacking.py
@@ -90,11 +90,11 @@ def workload_bin_packing(query, capacity, algorithm):
 
 def get_binpacked_workload(filedate):
     # reverse order of credential data
-    user_cred = pickle.load(open(f"{AWS_CONST.LOCAL_PATH}/user_cred_df_100_199.pkl", "rb"))
+    user_cred = pickle.load(open(f"{AWS_CONST.LOCAL_PATH}/user_cred_df.pkl", "rb"))
     user_cred = user_cred[::-1]
-    pickle.dump(user_cred, open(f"{AWS_CONST.LOCAL_PATH}/user_cred_df_100_199.pkl", "wb"))
-    with open(f"{AWS_CONST.LOCAL_PATH}/user_cred_df_100_199.pkl", 'rb') as f:
-        s3.upload_fileobj(f, STORAGE_CONST.BUCKET_NAME, 'rawdata/aws/localfile/user_cred_df.pkl')
+    pickle.dump(user_cred, open(f"{AWS_CONST.LOCAL_PATH}/user_cred_df.pkl", "wb"))
+    with open(f"{AWS_CONST.LOCAL_PATH}/user_cred_df.pkl", 'rb') as f:
+        s3.upload_fileobj(f, STORAGE_CONST.BUCKET_NAME, f'{AWS_CONST.S3_LOCAL_FILES_SAVE_PATH}/user_cred_df.pkl')
 
     DIRLIST = os.listdir(f"{AWS_CONST.LOCAL_PATH}/")
     if f"{filedate}_binpacked_workloads.pkl" in DIRLIST:
@@ -155,5 +155,5 @@ if __name__=="__main__":
         send_slack_message(e)
     s3_client = boto3.client('s3')
     pickle.dump(workload, open(f"{AWS_CONST.LOCAL_PATH}/workloads.pkl", "wb"))
-    s3_client.upload_fileobj(open(f"{AWS_CONST.LOCAL_PATH}/workloads.pkl", "rb"), STORAGE_CONST.BUCKET_NAME, f"rawdata/aws/localfile/workloads.pkl")
+    s3_client.upload_fileobj(open(f"{AWS_CONST.LOCAL_PATH}/workloads.pkl", "rb"), STORAGE_CONST.BUCKET_NAME, f"{AWS_CONST.S3_LOCAL_FILES_SAVE_PATH}/workloads.pkl")
 

--- a/collector/spot-dataset/aws/ec2_collector/workload_binpacking.py
+++ b/collector/spot-dataset/aws/ec2_collector/workload_binpacking.py
@@ -90,7 +90,11 @@ def workload_bin_packing(query, capacity, algorithm):
 
 def get_binpacked_workload(filedate):
     # reverse order of credential data
-    user_cred = pickle.load(open(f"{AWS_CONST.LOCAL_PATH}/user_cred_df.pkl", "rb"))
+    user_cred = None
+    try:
+        user_cred = pickle.load(s3.Object(STORAGE_CONST.BUCKET_NAME, f'{AWS_CONST.S3_LOCAL_FILES_SAVE_PATH}/user_cred_df.pkl').get()['Body'])
+    except:
+        user_cred = pickle.load(open(f"{AWS_CONST.LOCAL_PATH}/user_cred_df.pkl", "rb"))
     user_cred = user_cred[::-1]
     pickle.dump(user_cred, open(f"{AWS_CONST.LOCAL_PATH}/user_cred_df.pkl", "wb"))
     with open(f"{AWS_CONST.LOCAL_PATH}/user_cred_df.pkl", 'rb') as f:

--- a/collector/spot-dataset/aws/ec2_collector/workload_binpacking.py
+++ b/collector/spot-dataset/aws/ec2_collector/workload_binpacking.py
@@ -93,6 +93,8 @@ def get_binpacked_workload(filedate):
     user_cred = pickle.load(open(f"{AWS_CONST.LOCAL_PATH}/user_cred_df_100_199.pkl", "rb"))
     user_cred = user_cred[::-1]
     pickle.dump(user_cred, open(f"{AWS_CONST.LOCAL_PATH}/user_cred_df_100_199.pkl", "wb"))
+    with open(f"{AWS_CONST.LOCAL_PATH}/user_cred_df_100_199.pkl", 'rb') as f:
+        s3.upload_fileobj(f, STORAGE_CONST.BUCKET_NAME, 'rawdata/aws/localfile/user_cred_df.pkl')
 
     DIRLIST = os.listdir(f"{AWS_CONST.LOCAL_PATH}/")
     if f"{filedate}_binpacked_workloads.pkl" in DIRLIST:

--- a/const_config.py
+++ b/const_config.py
@@ -33,6 +33,18 @@ class AwsCollector(object):
     def LOCAL_PATH():
         return "/home/ubuntu/spotlake/collector/spot-dataset/aws/ec2_collector"
 
+    @constant
+    def S3_LATEST_DATA_SAVE_PATH():
+        return "latest_data/latest_aws.json"
+
+    @constant
+    def S3_LOCAL_FILES_SAVE_PATH():
+        return "rawdata/aws/localfile"
+
+    @constant
+    def S3_WORKLOAD_SAVE_PATH():
+        return "rawdata/aws/workloads"
+
 class AzureCollector(object):
     @constant
     def SLACK_WEBHOOK_URL():


### PR DESCRIPTION
현재 로컬에만 생성, 저장되어 활용되는 파일들은 다음과 같습니다.
* 2023-03-14_binpacked_workloads.pkl
* 2023-03-14_binpacked_workloads.pkl.gz
* 2023-03-14_ondemand_price_df.pkl
* 2023-03-14_ondemand_price_df.pkl.gz
* query-selector-aws.json
* user_cred_df_100_199.pkl
* latest_aws.json
* latest_df.pkl
* workloads.pkl

이 중, {filedate}_ 로 시작하거나 .json으로 끝나는 파일들은 s3에 업로드하기 위해 일시적으로 생성해두는 파일일 뿐으로, 코드에서 활용되지 않습니다.

코드에서 데이터를 수집할 때, 로컬에 반드시 필요한 데이터는 user_cred_df_100_199.pkl과 latest_df.pkl, workloads.pkl입니다.
user_cred_df_100_199.pkl는 매일매일 순서가 뒤바뀌기 때문에, 계정들의 순서 정보가 sps 수집의 unique query에 중요한 영향을 미치므로 반드시 존재해야 하고,
latest_df.pkl은 changed-row 방식으로 데이터를 저장하기 위해 current_df와 비교하기 위한 previous_df를 불러오기 위해 꼭 필요한 데이터이며,
workloads.pkl은 workload 생성에 실패할 경우 백업용으로 불러올 워크로드가 항상 존재하고 있어야 하기 때문에 꼭 필요한 데이터입니다.

때문에 위 3개의 데이터를 s3에 백업하고, 기존에 로컬에서 불러오던 파일을 s3에서 받아올 수 있도록 수정하였습니다.

테스트가 힘든 코드라 실제 merge까지는 조심해서 살펴봐야 할 필요가 있습니다.