### PR TITLE
fix s3 error in creating workload process

### DIFF
--- a/collector/spot-dataset/aws/ec2_collector/workload_binpacking.py
+++ b/collector/spot-dataset/aws/ec2_collector/workload_binpacking.py
@@ -90,6 +90,7 @@ def workload_bin_packing(query, capacity, algorithm):
 
 def get_binpacked_workload(filedate):
     # reverse order of credential data
+    s3_client = boto3.client('s3')
     user_cred = None
     try:
         user_cred = pickle.load(open(f"{AWS_CONST.LOCAL_PATH}/user_cred_df.pkl", "rb"))

--- a/collector/spot-dataset/aws/ec2_collector/workload_binpacking.py
+++ b/collector/spot-dataset/aws/ec2_collector/workload_binpacking.py
@@ -90,15 +90,16 @@ def workload_bin_packing(query, capacity, algorithm):
 
 def get_binpacked_workload(filedate):
     # reverse order of credential data
-    s3_client = boto3.client('s3')
     user_cred = None
     try:
         user_cred = pickle.load(open(f"{AWS_CONST.LOCAL_PATH}/user_cred_df.pkl", "rb"))
     except:
-        user_cred = pickle.load(s3.Object(STORAGE_CONST.BUCKET_NAME, f'{AWS_CONST.S3_LOCAL_FILES_SAVE_PATH}/user_cred_df.pkl').get()['Body'])
+        s3_resource = boto3.resource('s3')
+        user_cred = pickle.load(s3_resource.Object(STORAGE_CONST.BUCKET_NAME, f'{AWS_CONST.S3_LOCAL_FILES_SAVE_PATH}/user_cred_df.pkl').get()['Body'])
     user_cred = user_cred[::-1]
     pickle.dump(user_cred, open(f"{AWS_CONST.LOCAL_PATH}/user_cred_df.pkl", "wb"))
     with open(f"{AWS_CONST.LOCAL_PATH}/user_cred_df.pkl", 'rb') as f:
+        s3_client = boto3.client('s3')
         s3_client.upload_fileobj(f, STORAGE_CONST.BUCKET_NAME, f'{AWS_CONST.S3_LOCAL_FILES_SAVE_PATH}/user_cred_df.pkl')
 
     DIRLIST = os.listdir(f"{AWS_CONST.LOCAL_PATH}/")

--- a/collector/spot-dataset/aws/ec2_collector/workload_binpacking.py
+++ b/collector/spot-dataset/aws/ec2_collector/workload_binpacking.py
@@ -99,7 +99,7 @@ def get_binpacked_workload(filedate):
     user_cred = user_cred[::-1]
     pickle.dump(user_cred, open(f"{AWS_CONST.LOCAL_PATH}/user_cred_df.pkl", "wb"))
     with open(f"{AWS_CONST.LOCAL_PATH}/user_cred_df.pkl", 'rb') as f:
-        s3.upload_fileobj(f, STORAGE_CONST.BUCKET_NAME, f'{AWS_CONST.S3_LOCAL_FILES_SAVE_PATH}/user_cred_df.pkl')
+        s3_client.upload_fileobj(f, STORAGE_CONST.BUCKET_NAME, f'{AWS_CONST.S3_LOCAL_FILES_SAVE_PATH}/user_cred_df.pkl')
 
     DIRLIST = os.listdir(f"{AWS_CONST.LOCAL_PATH}/")
     if f"{filedate}_binpacked_workloads.pkl" in DIRLIST:


### PR DESCRIPTION
credentials 파일을 뒤집고 S3에 업로드 할 때, S3가 선언되지 않아 업로드 과정에서 에러 발생.