### PR TITLE
latest_gcp.json 파일에서 id 값 변경

### DIFF
--- a/collector/spot-dataset/gcp/lambda/upload_data.py
+++ b/collector/spot-dataset/gcp/lambda/upload_data.py
@@ -84,6 +84,7 @@ def update_latest(data, timestamp):
     data['Savings'] = round(
         (data['OnDemand Price'] - data['Spot Price']) / data[
             'OnDemand Price'] * 100)
+    data.reset_index(drop=True, inplace=True)
     data = data.replace(-0, -1)
     data['id'] = data.index + 1
     data = pd.DataFrame(data, columns=['id', 'InstanceType', 'Region', 'OnDemand Price',


### PR DESCRIPTION
현재 수집 모듈에서는 drop -1 과정이 이뤄지면서 기존 dataframe 의 인덱스로 id가 부여되었습니다.
17시에 이뤄진 수집 모듈에서 이를 확인하였고, rawdata 나 tsdb 혹은 compare 단계에서 영향을 미치지는 않아 정상동작했습니다.

upload latest 시 index 를 다시 조정한 후 id 를 부여하도록 코드를 수정했습니다.

- 변경 전
![image](https://user-images.githubusercontent.com/72314987/231396181-81065bdd-6279-4c24-9dd2-958044da33ef.png)

- 변경 후
![image](https://user-images.githubusercontent.com/72314987/231396259-d4baec9f-7f5e-472e-be89-36a47da9d55b.png)
