### PR TITLE
latest 에서 savings 제거 및 rawdata 에 savings 추가

### DIFF
--- a/collector/spot-dataset/gcp/lambda/upload_data.py
+++ b/collector/spot-dataset/gcp/lambda/upload_data.py
@@ -81,9 +81,6 @@ def upload_timestream(data, timestamp):
 
 def update_latest(data, timestamp):
     filename = 'latest_gcp.json'
-    data['Savings'] = round(
-        (data['OnDemand Price'] - data['Spot Price']) / data[
-            'OnDemand Price'] * 100)
     data.reset_index(drop=True, inplace=True)
     data = data.replace(-0, -1)
     data['id'] = data.index + 1

--- a/collector/spot-dataset/gcp/lambda/upload_data.py
+++ b/collector/spot-dataset/gcp/lambda/upload_data.py
@@ -106,6 +106,9 @@ def update_latest(data, timestamp):
 
 def save_raw(data, timestamp):
     SAVE_FILENAME = f"{LOCAL_PATH}/spotlake_" + f"{timestamp}.csv.gz"
+    data['Savings'] = round(
+        (data['OnDemand Price'] - data['Spot Price']) / data[
+            'OnDemand Price'] * 100)
     data.to_csv(SAVE_FILENAME, index=False, compression='gzip')
     session = boto3.Session()
     s3 = session.client('s3')


### PR DESCRIPTION
#425 에서 말씀드린 latest 에서 savings 를 제거하는 PR 입니다.

햔가지 알게 된 것이, savings 가 그동안 latest 에서 저장되어오고 rawdata에는 없는것으로 확인 되었습니다.

aws와 azure 의 데이터를 확인해보니 두 벤더 모두 rawdata 에는 savings 값이 저장되어있었습니다.
따라서 이번 PR 에서 latest에서는 savings 삭제, rawdata에는 savings 를 추가하는 코드를 추가하였습니다.

추후 전처리를 용이하게 하기 위해서는 그동안 모아온 rawdata에 savings 를 추가해둬야 할 것 같습니다.
#422 이슈를 진행할 예정이라서 해당 부분도 포함해서 작업하면 좋을 것 같습니다.

