### PR TITLE
update azure collecotor avoid 429 error

### DIFF
--- a/collector/spot-dataset/azure/lambda/current_collector/load_price.py
+++ b/collector/spot-dataset/azure/lambda/current_collector/load_price.py
@@ -13,8 +13,7 @@ AZURE_CONST = AzureCollector()
 
 price_list = []
 response_dict = {}
-MAX_SKIP = 2000
-SKIP_NUM_LIST = [i*100 for i in range(AZURE_CONST.MAX_SKIP)]
+SKIP_NUM_LIST = [i*1000 for i in range(AZURE_CONST.MAX_SKIP)]
 event = threading.Event()
 lock = threading.Lock()
 
@@ -143,5 +142,6 @@ def collect_price_with_multithreading():
 
     price_df = pd.DataFrame(price_list)
     savings_df = preprocessing_price(price_df)
+    savings_df = savings_df.drop_duplicates(subset=['InstanceTier', 'InstanceType', 'Region'], keep='first')
 
     return savings_df

--- a/collector/spot-dataset/azure/lambda/current_collector/load_price.py
+++ b/collector/spot-dataset/azure/lambda/current_collector/load_price.py
@@ -1,3 +1,5 @@
+import time
+import random
 import requests
 import pandas as pd
 import numpy as np
@@ -14,6 +16,7 @@ response_dict = {}
 MAX_SKIP = 2000
 SKIP_NUM_LIST = [i*100 for i in range(AZURE_CONST.MAX_SKIP)]
 event = threading.Event()
+lock = threading.Lock()
 
 
 # get instancetier from armSkuName
@@ -54,6 +57,9 @@ def get_instaceType(armSkuName):
 
 # get price data using the API
 def get_price(skip_num):
+    sleep_time = random.uniform(0, 5)
+    time.sleep(sleep_time)
+
     get_link = AZURE_CONST.GET_PRICE_URL + str(skip_num)
     response = requests.get(get_link)
 
@@ -74,7 +80,9 @@ def get_price(skip_num):
 
         return
 
+    lock.acquire()
     price_list.extend(price_data)
+    lock.release()
 
     return
 

--- a/collector/spot-dataset/azure/lambda/current_collector/load_price.py
+++ b/collector/spot-dataset/azure/lambda/current_collector/load_price.py
@@ -1,5 +1,3 @@
-import time
-import random
 import requests
 import pandas as pd
 import numpy as np

--- a/collector/spot-dataset/azure/lambda/current_collector/load_price.py
+++ b/collector/spot-dataset/azure/lambda/current_collector/load_price.py
@@ -56,9 +56,6 @@ def get_instaceType(armSkuName):
 
 # get price data using the API
 def get_price(skip_num):
-    sleep_time = random.uniform(0, 5)
-    time.sleep(sleep_time)
-
     get_link = AZURE_CONST.GET_PRICE_URL + str(skip_num)
     response = requests.get(get_link)
 

--- a/const_config.py
+++ b/const_config.py
@@ -104,7 +104,7 @@ class AzureCollector(object):
 
     @constant
     def GET_PRICE_URL():
-        return "https://prices.azure.com:443/api/retail/prices?$filter=serviceName%20eq%20%27Virtual%20Machines%27%20and%20priceType%20eq%20%27Consumption%27%20and%20unitOfMeasure%20eq%20%271%20Hour%27&$skip="
+        return "https://prices.azure.com:443/api/retail/prices?$filter=serviceName eq 'Virtual Machines' and priceType eq 'Consumption' and unitOfMeasure eq '1 Hour' and  contains(productName, 'Windows') eq false and contains(meterName, 'Low Priority') eq false  and contains(meterName, 'Expired') eq false and contains(location, 'Gov') eq false and contains(location, 'ATT') eq false &$skip="
     
     @constant
     def FILTER_LOCATIONS():
@@ -112,7 +112,7 @@ class AzureCollector(object):
     
     @constant
     def MAX_SKIP():
-        return 2000
+        return 200
 
 class GcpCollector(object):
     @constant


### PR DESCRIPTION
Azure collector에서 수집 데이터 중복과 429에러가 발생하여 그 원인이 멀티쓰레딩에 있는것으로 예상하여 
쓰레드락과 한번에 너무 많은 API 요청을 보내지 않도록 요청정 0~5초 정도 sleep하는 코드를 추가하였습니다.