### PR TITLE
GCP CloudWatch로 수집 개수 전송

### DIFF
--- a/const_config.py
+++ b/const_config.py
@@ -126,4 +126,11 @@ class GcpCollector(object):
     @constant
     def LOCAL_PATH():
         return "/tmp"
-        
+    
+    @constant
+    def LOG_GROUP_NAME():
+        return "Collection-Data-Count"
+    
+    @constant
+    def LOG_STREAM_NAME():
+        return "GCP-Count"

--- a/const_config.py
+++ b/const_config.py
@@ -128,7 +128,7 @@ class GcpCollector(object):
         return "/tmp"
     
     @constant
-    def LOG_GROUP_NAME():
+    def SPOT_DATA_COLLECTION_LOG_GROUP_NAME():
         return "Collection-Data-Count"
     
     @constant


### PR DESCRIPTION
https://github.com/ddps-lab/spotlake/issues/453 에서 진행중인 매 수집 시마다 데이터 수집 개수를 확인하여 이상치가 발생하면 알람을 발생시켜 Slack으로 알림을 전송하는 코드를 GCP에 적용하였습니다.

<img width="433" alt="image" src="https://github.com/ddps-lab/spotlake/assets/106056971/b8a12f4d-67d3-4c92-a7a8-7c7c815d2d24">

GCP의 경우는 OndemandPrice, SpotPrice 개수가 전송됩니다.