### PR TITLE
aws collector s3 관련 에러 수정

### DIFF
--- a/collector/spot-dataset/aws/ec2_collector/workload_binpacking.py
+++ b/collector/spot-dataset/aws/ec2_collector/workload_binpacking.py
@@ -89,6 +89,7 @@ def workload_bin_packing(query, capacity, algorithm):
 
 
 def get_binpacked_workload(filedate):
+    s3_client = boto3.client('s3')
     # reverse order of credential data
     user_cred = None
     try:
@@ -139,7 +140,6 @@ def get_binpacked_workload(filedate):
         user_queries = []    
 
     # need to change file location
-    s3_client = boto3.client('s3')
     pickle.dump(user_queries_list, open(f"{AWS_CONST.LOCAL_PATH}/{filedate}_binpacked_workloads.pkl", 'wb'))
     gzip.open(f"{AWS_CONST.LOCAL_PATH}/{filedate}_binpacked_workloads.pkl.gz", "wb").writelines(open(f"{AWS_CONST.LOCAL_PATH}/{filedate}_binpacked_workloads.pkl", "rb"))
     s3_client.upload_fileobj(open(f"{AWS_CONST.LOCAL_PATH}/{filedate}_binpacked_workloads.pkl.gz", "rb"), STORAGE_CONST.BUCKET_NAME, f"rawdata/aws/workloads/{today}/binpacked_workloads.pkl.gz")

--- a/collector/spot-dataset/aws/ec2_collector/workload_binpacking.py
+++ b/collector/spot-dataset/aws/ec2_collector/workload_binpacking.py
@@ -90,12 +90,13 @@ def workload_bin_packing(query, capacity, algorithm):
 
 def get_binpacked_workload(filedate):
     s3_client = boto3.client('s3')
+    s3_resource = boto3.resource('s3')
     # reverse order of credential data
     user_cred = None
     try:
         user_cred = pickle.load(open(f"{AWS_CONST.LOCAL_PATH}/user_cred_df.pkl", "rb"))
     except:
-        user_cred = pickle.load(s3.Object(STORAGE_CONST.BUCKET_NAME, f'{AWS_CONST.S3_LOCAL_FILES_SAVE_PATH}/user_cred_df.pkl').get()['Body'])
+        user_cred = pickle.load(s3_resource.Object(STORAGE_CONST.BUCKET_NAME, f'{AWS_CONST.S3_LOCAL_FILES_SAVE_PATH}/user_cred_df.pkl').get()['Body'])
     user_cred = user_cred[::-1]
     pickle.dump(user_cred, open(f"{AWS_CONST.LOCAL_PATH}/user_cred_df.pkl", "wb"))
     with open(f"{AWS_CONST.LOCAL_PATH}/user_cred_df.pkl", 'rb') as f:
@@ -109,8 +110,6 @@ def get_binpacked_workload(filedate):
         for filename in DIRLIST:
             if "binpacked_workloads.pkl" in filename:
                 os.remove(f"{AWS_CONST.LOCAL_PATH}/{filename}")
-    
-    s3_resource = boto3.resource('s3')
 
     workloads = num_az_by_region()
     today = "/".join(filedate.split("-"))


### PR DESCRIPTION
s3_client와 s3_resource가 앞부분에서 s3로 선언되어있었고 이를 수정한 것이 #467 PR입니다.

그런데 s3를 s3_client와 s3_resource로 수정하면서, s3_client와 s3_resource의 선언부의 위치를 수정하지 않아 추가 에러가 발생했습니다.

관련해서 살펴보니, collector-refactoring branch에서는 이 부분이 수정되어 있지만,
main으로 Merge가 되지 않았었던 것 같습니다. #417
(당시에는 PR Merge 이전에 급하게 오류 해결을 위해 오프라인에 먼저 적용하며 테스트 진행)

#417 PR은 close하고, 본 PR을 Merge하도록 하겠습니다.