### PR TITLE
쿼리 시에 리전을 한 번만 받아올 수 있도록 변경

### DIFF
--- a/collector/spot-dataset/aws/sps_collector/sps_query_api.py
+++ b/collector/spot-dataset/aws/sps_collector/sps_query_api.py
@@ -8,6 +8,8 @@ IDX_INSTANCE_TYPE = 0
 IDX_REGION_NAMES = 1
 IDX_NUMBER_RESPONSE = 2
 
+REGION=None
+
 # SPS 점수를 계정별로 받아오는 함수입니다.
 # args는 다음과 같이 구성된 튜플이어야 합니다
 # (credential, scenarios, target_capacity)
@@ -78,6 +80,8 @@ def get_token():
         raise Exception("토큰을 가져오는 데 실패했습니다. 상태 코드: {}".format(response.status_code))
 
 def get_region():
+    if REGION is not None:
+        return REGION
     token = get_token()
     if token:
         metadata_url = "http://169.254.169.254/latest/dynamic/instance-identity/document"
@@ -85,7 +89,8 @@ def get_region():
         response = requests.get(metadata_url, headers=headers)
         if response.status_code == 200:
             document = response.json()
-            return document.get("region")
+            REGION = document.get("region")
+            return REGION
         else:
             raise Exception("메타데이터를 가져오는 데 실패했습니다. 상태 코드: {}".format(response.status_code))
     else:


### PR DESCRIPTION
원래 쿼리에서는
리전을 각 시나리오마다 받아왔었는데
이제 스크립트 실행 할 때 한 번만 받아오도록 설정했습니다.