### PR TITLE
Use encoded json data

### DIFF
--- a/.github/workflows/gcp-lambda-sync.yml
+++ b/.github/workflows/gcp-lambda-sync.yml
@@ -21,7 +21,7 @@ jobs:
       - name: checkout source code
         uses: actions/checkout@v1
       - name: Create JSON file from environment variable
-        run: echo "${{ secrets.GCP_KEY_JSON }}" > ${{ secrets.GCP_JSON_FILENAME }}
+        run: echo "${{ secrets.GCP_KEY_JSON_BASE64 }}" | base64 --decode > ${{ secrets.GCP_JSON_FILENAME }}
       - name: Zip lambda_function code
         run: |
           zip -r gcp_lambda.zip ./utility/slack_msg_sender.py


### PR DESCRIPTION
현재 raw한 json 키 파일 값을 secret 값으로 사용했는데,
출력을 echo "${{ secrets.GCP_KEY_JSON }}" > 파일이름 으로 사용하고 있습니다.
"" 안에 ""가 다시 들어가다 보니, ""가 없는 json 파일 데이터 형태로 출력이 됩니다.

안정성을 위해서 base64로 인코딩한 데이터를 사용하려고 합니다.