### PR TITLE
Github Actions가 (S3 web 배포) 제대로 동작하지 않는 문제 해결

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -21,4 +21,4 @@ jobs:
       - name: "Sync with AWS S3"
         run: aws s3 sync ./frontend/build/ s3://${{ secrets.AWS_SPOTLAKE_S3_BUCKET_NAME }} --acl public-read --delete
       - name: "Create Invalidation"
-        run: aws cloudfront create-invalidation --distribution-id EM3KPE8H4PYYF --paths "/*"
+        run: aws cloudfront create-invalidation --distribution-id E2VA9I0M7YAVHW --paths "/*"


### PR DESCRIPTION
Spotlake repo에서 S3로 배포하는 Github Action에서 사용되는 Credential이 이전 Prod계정에서 이전하면서 수정되지 않아 Github Actions이 정상적으로 동작하지 않는 문제를 해결합니다.
Credential은 Secret 값으로 구성되어있으나 Distribution ID는 Github actions workflow에 하드 코딩되어있어 이를 수정하여 정상적으로 github actions가 동작하도록 수정합니다.