### PR TITLE
compare_sps 개발을 위한 사전 변경

### DIFF
--- a/collector/spot-dataset/azure/lambda/current_collector/load_sps.py
+++ b/collector/spot-dataset/azure/lambda/current_collector/load_sps.py
@@ -185,7 +185,7 @@ def execute_spot_placement_score_task_by_parameter_pool_df(api_calls_df, availab
                                 "Score": score.get("score")
                             }
                             if availability_zones:
-                                score_data["AvailabilityZone"] = score.get("availabilityZone")
+                                score_data["AvailabilityZone"] = score.get("availabilityZone", "SINGLE_ZONE")
 
                             results.append(score_data)
 


### PR DESCRIPTION
compare_sps 개발을 위한 사전 변경:
availabilityZone 이 True일때도, 결과에는 availability_zone 필드 가 없는 행이 있습니다. 
이런 상황의 availability_zone 값을 None이 아닌 SINGLE_ZONE 으로 변경합니다.