### PR TITLE
SPS T2/T3 threshold 기록 조건 수정

### DIFF
--- a/.github/workflows/azure-sps-lambda-sync.yml
+++ b/.github/workflows/azure-sps-lambda-sync.yml
@@ -1,15 +1,9 @@
 name: deploy azure sps files to lambda
+
+# Legacy ZIP Lambda rollback path. The production Azure collector runs on Batch.
 on:
-  push:
-    branches:
-      - 'main'
-    paths:
-      - 'collector/spot-dataset/azure/lambda/current_collector/lambda_function_sps.py'
-      - 'collector/spot-dataset/azure/lambda/current_collector/load_price.py'
-      - 'collector/spot-dataset/azure/lambda/current_collector/load_sps.py'
-      - 'const_config.py'
-      - 'collector/spot-dataset/azure/lambda/current_collector/utils/**'
-      - 'collector/spot-dataset/azure/lambda/current_collector/sps_module/**'
+  workflow_dispatch:
+
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.SPOTRANK_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.SPOTRANK_SECRET_ACCESS_KEY }}

--- a/collector/spot-dataset/aws/batch-test/sps/sps_query_api.py
+++ b/collector/spot-dataset/aws/batch-test/sps/sps_query_api.py
@@ -77,7 +77,7 @@ def query_sps(args):
             else:
                 sps_dict["T3"].append(0)
 
-            if score['Score'] == 2:
+            if score['Score'] >= 2:
                 sps_dict["T2"].append(target_capacity)
             else:
                 sps_dict["T2"].append(0)

--- a/collector/spot-dataset/aws/batch/sps/sps_query_api.py
+++ b/collector/spot-dataset/aws/batch/sps/sps_query_api.py
@@ -77,7 +77,7 @@ def query_sps(args):
             else:
                 sps_dict["T3"].append(0)
 
-            if score['Score'] == 2:
+            if score['Score'] >= 2:
                 sps_dict["T2"].append(target_capacity)
             else:
                 sps_dict["T2"].append(0)

--- a/collector/spot-dataset/aws/ec2/sps/sps_query_api.py
+++ b/collector/spot-dataset/aws/ec2/sps/sps_query_api.py
@@ -71,12 +71,12 @@ def query_sps(args):
             sps_dict["SPS"].append(int(score["Score"]))
             sps_dict["TargetCapacity"].append(target_capacity)
             
-            if score['Score'] == 3:
+            if score['Score'] >= 3:
                 sps_dict["T3"].append(target_capacity)
             else:
                 sps_dict["T3"].append(0)
 
-            if score['Score'] == 2:
+            if score['Score'] >= 2:
                 sps_dict["T2"].append(target_capacity)
             else:
                 sps_dict["T2"].append(0)

--- a/collector/spot-dataset/azure/batch-test/sps/load_sps.py
+++ b/collector/spot-dataset/azure/batch-test/sps/load_sps.py
@@ -199,7 +199,7 @@ def execute_spot_placement_score_task_by_parameter_pool_df(api_calls_df, desired
                                 "InstanceType": SS_Resources.region_map_and_instance_map_tmp['instance_map'].get(
                                     score.get("sku", ""), {}).get("InstanceTypeOld"),
                                 "Score": map_score_to_int(score.get("score")),
-                                "T3": desired_count if map_score_to_int(score.get("score")) == 3 else 0,
+                                "T3": desired_count if map_score_to_int(score.get("score")) >= 3 else 0,
                                 "T2": desired_count if map_score_to_int(score.get("score")) >= 2 else 0
                             }
                             if availability_zones is True:

--- a/collector/spot-dataset/azure/batch/sps/load_sps.py
+++ b/collector/spot-dataset/azure/batch/sps/load_sps.py
@@ -199,7 +199,7 @@ def execute_spot_placement_score_task_by_parameter_pool_df(api_calls_df, desired
                                 "InstanceType": SS_Resources.region_map_and_instance_map_tmp['instance_map'].get(
                                     score.get("sku", ""), {}).get("InstanceTypeOld"),
                                 "Score": map_score_to_int(score.get("score")),
-                                "T3": desired_count if map_score_to_int(score.get("score")) == 3 else 0,
+                                "T3": desired_count if map_score_to_int(score.get("score")) >= 3 else 0,
                                 "T2": desired_count if map_score_to_int(score.get("score")) >= 2 else 0
                             }
                             if availability_zones is True:

--- a/collector/spot-dataset/azure/lambda/current_collector/load_sps.py
+++ b/collector/spot-dataset/azure/lambda/current_collector/load_sps.py
@@ -214,7 +214,7 @@ def execute_spot_placement_score_task_by_parameter_pool_df(api_calls_df, desired
                                 "InstanceType": SS_Resources.region_map_and_instance_map_tmp['instance_map'].get(
                                     score.get("sku", ""), {}).get("InstanceTypeOld"),
                                 "Score": map_score_to_int(score.get("score")),
-                                "T3": desired_count if map_score_to_int(score.get("score")) == 3 else 0,
+                                "T3": desired_count if map_score_to_int(score.get("score")) >= 3 else 0,
                                 "T2": desired_count if map_score_to_int(score.get("score")) >= 2 else 0
                             }
                             if availability_zones is True:


### PR DESCRIPTION
## 문제

일부 SPS score에서 T2가 T3보다 작은 값으로 기록될 수 있었습니다.

- AWS T2는 score가 정확히 2일 때만 요청 capacity를 기록했습니다.
- Azure T3는 mapped score가 정확히 3일 때만 요청 capacity를 기록했습니다.
- 더 높은 numeric score가 들어오면 해당 threshold를 충족하면서도 값이 0으로 남을 수 있었습니다.

## 변경

- AWS T2 기록 조건을 `score >= 2`로 통일합니다.
- Azure T3 기록 조건을 `score >= 3`으로 통일합니다.
- AWS batch, batch-test, EC2와 Azure batch, batch-test, legacy Lambda 구현에 같은 조건을 적용합니다.

## CI/CD 안전성

Azure SPS ZIP Lambda deploy workflow를 `workflow_dispatch` 전용으로 변경했습니다. 현재 Production Azure collector는 AWS Batch에서 실행되며, 이 PR을 `main`에 merge해도 legacy Lambda code update가 자동 실행되지 않습니다.

## Merge 관계

이 PR의 전체 commit history는 Draft PR #626의 `titans` 브랜치에도 포함돼 있습니다. 이 PR을 먼저 **Create a merge commit** 방식으로 merge하면 #626에서 이미 `main`에 반영된 변경이 자동으로 제외됩니다.

## 검증

```text
uv run python -m py_compile \
  collector/spot-dataset/aws/batch-test/sps/sps_query_api.py \
  collector/spot-dataset/aws/batch/sps/sps_query_api.py \
  collector/spot-dataset/aws/ec2/sps/sps_query_api.py \
  collector/spot-dataset/azure/batch-test/sps/load_sps.py \
  collector/spot-dataset/azure/batch/sps/load_sps.py \
  collector/spot-dataset/azure/lambda/current_collector/load_sps.py
```
