### PR TITLE
fix(frontend): translate construction page copy to English

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -28,9 +28,9 @@ export default function Home() {
           Under Construction
         </h1>
         <p className="mt-6 max-w-2xl text-pretty text-base leading-7 text-muted-foreground sm:text-lg sm:leading-8">
-          SpotLake를 더 나은 모습으로 개선하고 있습니다.
+          We are working to make SpotLake better than ever.
           <br className="hidden sm:block" />
-          페이지 및 데이터 공유 관련 문의는 아래 이메일로 연락해 주세요.
+          For inquiries about the website or dataset access, please reach out via the email below.
         </p>
 
         <a


### PR DESCRIPTION
Replaces the two Korean body-copy lines on the Under Construction landing page with English equivalents, since the site is English-only. No layout or logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TDUXyEkZN1mDEffpK1uEe4